### PR TITLE
allow failure for nightly python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
     name: mypy
     script:
     - mypy yaqc_bluesky
+  allow_failures:
+    - python: nightly
 deploy:
   provider: script
   script: flit publish


### PR DESCRIPTION
currently `bluesky` is broken on nightly... this shouldn't result in red CI in my opinion