### PR TITLE
use yaqd_core testing

### DIFF
--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -2,6 +2,7 @@ import pathlib
 import time
 import subprocess
 import yaqc_bluesky
+from yaqd_core import testing
 from bluesky import RunEngine
 from bluesky.plans import scan
 
@@ -9,35 +10,10 @@ from bluesky.plans import scan
 __here__ = pathlib.Path(__file__).parent
 
 
-def run_daemon_entry_point(kind, config):
-    def decorator(function):
-        def wrapper():
-            with subprocess.Popen([f"yaqd-{kind}", "--config", config]) as proc:
-                tries = 100
-                while True:
-                    if tries <= 0:
-                        break
-                    try:
-                        function()
-                    except ConnectionError:
-                        time.sleep(0.1)
-                    except Exception:
-                        proc.terminate()
-                        raise
-                    else:
-                        break
-                    tries -= 1
-                proc.terminate()
-
-        return wrapper
-
-    return decorator
-
-
-@run_daemon_entry_point(
+@testing.run_daemon_entry_point(
     "fake-triggered-sensor", config=__here__ / "triggered-sensor-config.toml"
 )
-@run_daemon_entry_point(
+@testing.run_daemon_entry_point(
     "fake-continuous-hardware", config=__here__ / "continuous-hardware-config.toml"
 )
 def test_simple_scan():

--- a/tests/triggered_sensor/test_triggered_sensor.py
+++ b/tests/triggered_sensor/test_triggered_sensor.py
@@ -1,38 +1,14 @@
 import pathlib
 import time
 import subprocess
+from yaqd_core import testing
 import yaqc_bluesky
 
 
 config = pathlib.Path(__file__).parent / "config.toml"
 
 
-def run_daemon_entry_point(kind, config):
-    def decorator(function):
-        def wrapper():
-            with subprocess.Popen([f"yaqd-{kind}", "--config", config]) as proc:
-                tries = 100
-                while True:
-                    if tries <= 0:
-                        break
-                    try:
-                        function()
-                    except ConnectionError:
-                        time.sleep(0.1)
-                    except Exception:
-                        proc.terminate()
-                        raise
-                    else:
-                        break
-                    tries -= 1
-                proc.terminate()
-
-        return wrapper
-
-    return decorator
-
-
-@run_daemon_entry_point("fake-triggered-sensor", config=config)
+@testing.run_daemon_entry_point("fake-triggered-sensor", config=config)
 def test_describe_read():
     d = yaqc_bluesky.Device(39425)
     d.trigger()
@@ -41,7 +17,7 @@ def test_describe_read():
     assert describe_keys == read_keys
 
 
-@run_daemon_entry_point("fake-triggered-sensor", config=config)
+@testing.run_daemon_entry_point("fake-triggered-sensor", config=config)
 def test_hint_fields():
     d = yaqc_bluesky.Device(39425)
     fields = d.hints["fields"]
@@ -50,7 +26,7 @@ def test_hint_fields():
         assert field in d.read().keys()
 
 
-@run_daemon_entry_point("fake-triggered-sensor", config=config)
+@testing.run_daemon_entry_point("fake-triggered-sensor", config=config)
 def test_read():
     d = yaqc_bluesky.Device(39425)
     d.trigger()


### PR DESCRIPTION
Upstream now has a `run_daemon_entry_point` decorator, we don't need to replicate that here.