### PR TITLE
remove scheduled workflows

### DIFF
--- a/.github/workflows/bluesky-git.yml
+++ b/.github/workflows/bluesky-git.yml
@@ -2,8 +2,7 @@ name: bluesky-git
 
 on:
   push:
-  schedule:
-    - cron: '0 0 * * *'
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,8 +2,7 @@ name: python-test
 
 on:
   push:
-  schedule:
-    - cron: '0 0 * * *'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
github deactivates workflows with schedules after 60 days of inactivity

they do NOT then reactivate when a PR is opened :confounded: 