### PR TITLE
overload happi name regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- overloaded happi default for item name requirements: now any valid python identifier works
+
 ## [2021.1.0]
 
 ### Added

--- a/yaqc_bluesky/_happi.py
+++ b/yaqc_bluesky/_happi.py
@@ -1,14 +1,20 @@
-"""Support for happi - 
-pcdshub.github.io/happi 
+"""Support for happi -
+pcdshub.github.io/happi
 """
 
 
+import re
 import copy
 
 from happi.item import HappiItem, EntryInfo  # type: ignore
 
 
 class YAQItem(HappiItem):
+    name = EntryInfo(
+        "Shorthand Python-valid name for the Python instance",
+        optional=False,
+        enforce=re.compile(r"^[^\d\W]\w*\Z"),
+    )  # https://stackoverflow.com/a/10134719
     port = EntryInfo("TCP port.", enforce=int, optional=False)
     host = EntryInfo("Host.", optional=True, default="localhost")
     kwargs = copy.copy(HappiItem.kwargs)


### PR DESCRIPTION
I'm hoping that this will be changed by Happi, but in the meantime this works for our conventional yaq daemon names.