### PR TITLE
don't use most recent versions of pip for CI

### DIFF
--- a/.github/workflows/bluesky-git.yml
+++ b/.github/workflows/bluesky-git.yml
@@ -23,7 +23,7 @@ jobs:
         cd ..
         git clone https://github.com/bluesky/bluesky.git
         cd bluesky
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip!=20.3.4,!=21.0
         python -m pip install .
     - name: Install yaqc-bluesky
       run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip!=20.3.4,!=21.0
         python -m pip install --upgrade flit
         flit install 
     - name: Test with pytest


### PR DESCRIPTION
Most recent versions of pip are incompatable with flit.

See https://github.com/takluyver/flit/pull/388
