### PR TITLE
Don't define set when not implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - clients to has-position daemons now implement @property position, a common convention in bluesky
 
+### Removed
+- no longer implement "set" for hardware without position (had raised NotImplementedError)
+
 ## [2021.1.1]
 
 ### Changed

--- a/yaqc_bluesky/_base.py
+++ b/yaqc_bluesky/_base.py
@@ -63,9 +63,6 @@ class Base:
     def read_configuration(self) -> OrderedDict:
         return OrderedDict()
 
-    def set(self, position) -> Status:
-        raise NotImplementedError
-
     def trigger(self) -> Status:
         # should be overloaded for those devices that need a trigger
         st = Status()


### PR DESCRIPTION
The presence of the `set` attr messes with the recognition as "movable" (as any runtime checks simply look for the presence/absence of the attribute.

I don't think there is any reason to supply set which just raises NotImplementedError, as it is already handled by the has-position class mixin.

tests pass without it as well