### PR TITLE
Have default fallback for units and shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - state of busy no longer returned when devices are read
 - happi name field no longer overloaded, upstream now allows short names
 - happi now pinned to >= 1.9.0
+- Default for units and shape if not provided for the daemon
 
 ### Added
 - clients to has-position daemons now implement @property position, a common convention in bluesky

--- a/yaqc_bluesky/_is_sensor.py
+++ b/yaqc_bluesky/_is_sensor.py
@@ -16,8 +16,8 @@ class IsSensor(Base):
         for name in self._yaq_channel_names:
             meta = OrderedDict()
             meta["dtype"] = "number"
-            meta["units"] = self._yaq_channel_units[name]
-            meta["shape"] = self._yaq_channel_shapes[name]
+            meta["units"] = self._yaq_channel_units.get(name)
+            meta["shape"] = self._yaq_channel_shapes.get(name, ())
             out[f"{self.name}_{name}"] = OrderedDict(self._field_metadata, **meta)
         return out
 


### PR DESCRIPTION
See also https://gitlab.com/yaq/yaqd-ni/-/issues/7

This is the quick and dirty fix for a problem encountered with the NI daq... A more proper fix would occur with that daemon, but this is both easier and ensures that other daemons which _should_ define those but don't still will work as expected...

Another consideration would be to use https://docs.python.org/3/library/collections.html?highlight=defaultdict#collections.defaultdict though that does not serialize, of course, so likely not the right call...