### PR TITLE
remove overloaded happi name field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 - state of busy no longer returned when devices are read
+- happi name field no longer overloaded, upstream now allows short names
+- happi now pinned to >= 1.9.0
 
 ### Added
 - clients to has-position daemons now implement @property position, a common convention in bluesky

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ author-email = "blaise@untzag.com"
 home-page = "https://github.com/bluesky/yaqc-bluesky"
 description-file = "README.md"
 requires-python = ">3.7"
-requires = ["yaqc>=2020.7.3", 
-            "bluesky>=1.6.6", 
-            "happi>=1.8.4"]
+requires = ["yaqc>=2020.7.3",
+            "bluesky>=1.6.6",
+            "happi>=1.9.0"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",

--- a/yaqc_bluesky/_happi.py
+++ b/yaqc_bluesky/_happi.py
@@ -10,11 +10,6 @@ from happi.item import HappiItem, EntryInfo  # type: ignore
 
 
 class YAQItem(HappiItem):
-    name = EntryInfo(
-        "Shorthand Python-valid name for the Python instance",
-        optional=False,
-        enforce=re.compile(r"^[^\d\W]\w*\Z"),
-    )  # https://stackoverflow.com/a/10134719
     port = EntryInfo("TCP port.", enforce=int, optional=False)
     host = EntryInfo("Host.", optional=True, default="localhost")
     kwargs = copy.copy(HappiItem.kwargs)


### PR DESCRIPTION
Upstream has changed to allow our desired behavior. We should remove this overload now.

closes #48 