### PR TITLE
Integrate fields from the yaq client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ author-email = "blaise@untzag.com"
 home-page = "https://github.com/bluesky/yaqc-bluesky"
 description-file = "README.md"
 requires-python = ">3.7"
-requires = ["yaqc>=2020.7.3",
+requires = ["yaqc>=2021.10.0",
             "bluesky>=1.6.6",
             "happi>=1.9.0"]
 classifiers = [

--- a/tests/continuous_hardware/test_continuous_hardware.py
+++ b/tests/continuous_hardware/test_continuous_hardware.py
@@ -34,7 +34,7 @@ def test_scan():
     d = yaqc_bluesky.Device(39424)
     RE = RunEngine({})
     RE(scan([], d, -1, 0.33, 10))
-    assert math.isclose(d.read()[f"{d.name}_readback"]["value"], 0.33, abs_tol=1e-6)
+    assert math.isclose(d.read()[d.name]["value"], 0.33, abs_tol=1e-6)
 
 
 @testing.run_daemon_entry_point("fake-continuous-hardware", config=config)
@@ -42,10 +42,10 @@ def test_set():
     d = yaqc_bluesky.Device(39424)
     d.set(0)
     time.sleep(2)
-    assert math.isclose(d.read()[f"{d.name}_readback"]["value"], 0)
+    assert math.isclose(d.read()[d.name]["value"], 0)
     d.set(1)
     time.sleep(2)
-    assert math.isclose(d.read()[f"{d.name}_readback"]["value"], 1, abs_tol=1e-6)
+    assert math.isclose(d.read()[d.name]["value"], 1, abs_tol=1e-6)
 
 
 if __name__ == "__main__":

--- a/yaqc_bluesky/_has_position.py
+++ b/yaqc_bluesky/_has_position.py
@@ -10,17 +10,15 @@ class HasPosition(Base):
 
     def _describe(self, out):
         out = super()._describe(out)
-        meta = OrderedDict()
-        meta["dtype"] = "number"
-        meta["units"] = self.yaq_units
-        out[f"{self.name}_setpoint"] = OrderedDict(self._field_metadata, **meta)
-        out[f"{self.name}_readback"] = OrderedDict(self._field_metadata, **meta)
+        out[self.name] = out[f"{self.name}_position"]
+        out.move_to_end(self.name, last=False)
+        del out[f"{self.name}_position"]
         return out
 
     @property
     def hints(self):
         out = super().hints
-        out["fields"].append(f"{self.name}_readback")
+        out["fields"].append(f"{self.name}")
         return out
 
     @property
@@ -29,14 +27,9 @@ class HasPosition(Base):
 
     def _read(self, out, ts) -> OrderedDict:
         out = super()._read(out, ts)
-        out[f"{self.name}_setpoint"] = {
-            "value": self.yaq_client.get_destination(),
-            "timestamp": ts,
-        }
-        out[f"{self.name}_readback"] = {
-            "value": self.yaq_client.get_position(),
-            "timestamp": ts,
-        }
+        out[self.name] = out[f"{self.name}_position"]
+        out.move_to_end(self.name, last=False)
+        del out[f"{self.name}_position"]
         return out
 
     def set(self, value):


### PR DESCRIPTION
Closes #66

This is an initial implementation, there are some things including about
the underlying implementation of fields in yaq that I have questions
about smoothing out after working on this.

- Currently have to reach into the private variable `_protocol` of the
client
- Clunky access of fields with confusing "fields" entry in the record
type which is an avro thing, not the yaq field.

- Do we need the `_read` method, if so, do we need a parallel method for
configuration?

- We do not currently have _any_ fields defined in yaq that are
`dynamic=False`, thus I have not tested the configuration code really at
all. Further this makes me consider if dynamic is even doing what we
want it to at all.

# has-limits
- Currently kind of works, but I suspect would cause problems downstream
- Does not define shape at describe time
- We probably do not wish to expand ndim just for limits on each
hardware...
- We probably do not care to actually record it at every point, should
there be a way to declare not to do so: kind?
- should limits just be left out entirely, if so should it not be a
field or should it be special cased by calling `del` in `_has_limits.py`

# has-position
- Currently "double" define the position and destination as
"name_position/name_readback" and "name_destination/name_setpoint"
- I wish to assert that "name_readback" is _not_ the norm in the bluesky
community as far as I can tell, and in fact the position should just
simply be "name"

# general comments
- Do we care about order? I know I do some order dependent things in our
plans to determine the units (I take the units from the first entry in
describe... perhaps we could prefer whatever the standard readback key
is from previous discussion point
- Current order is all of the fields first in alphabetical order
(because yaq-traits alphabatizes it, not anything we do here), followed
by those defined by traits, which could potentially be removed based off
of conclusions from previous discussion points.