### PR TITLE
Dependent hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - human readable repr for device
+- Handling of devices which provide dependent hardware
 
 ## [2021.12.0]
 

--- a/yaqc_bluesky/_device.py
+++ b/yaqc_bluesky/_device.py
@@ -7,6 +7,7 @@ from ._has_position import HasPosition
 from ._is_sensor import IsSensor
 from ._has_measure_trigger import HasMeasureTrigger
 from ._has_mapping import HasMapping
+from ._has_dependent import HasDependent
 
 
 traits = [
@@ -24,6 +25,9 @@ def Device(port, *, host="127.0.0.1", name=None):
     for trait, cls in traits:
         if trait in c.traits:
             clss.append(cls)
+    # Special case for now, should likely become a proper trait
+    if hasattr(c, "get_dependent_hardware"):
+        clss.append(HasDependent)
     # make instance
     cls = type("YAQDevice", tuple(clss), {})
     obj = cls(yaq_client=c, name=name)

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -14,8 +14,11 @@ class HasDependent(Base):
         self._dependent_hardware = {}
         for k, v in self.yaq_client.get_dependent_hardware().items():
             try:
-                dev = Device(port=int(v.split(":", 1)[1]), host=v.split(":", 1)[0])
-                self._dependent_hardware[k] = dev
+                host, port = v.split(":", 1)
+                # replace hosts local to my own daemon, which may be remote to the client
+                if host in ("localhost", "127.0.0.1"):
+                    host = self.yaq_client._host
+                self._dependent_hardware[k] = Device(port=port, host=host)
             except ConnectionError as e:
                 warnings.warn(
                     f"Unable to connect to {k} from {self.name}, ignoring dependent relationship."

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -13,9 +13,6 @@ class HasDependent(Base):
 
         self._dependent_hardware = {}
         for k, v in self.yaq_client.get_dependent_hardware().items():
-            dev = Device(port=int(v.split(":", 1)[1]), host=v.split(":", 1)[0])
-            self._dependent_hardware[k] = dev
-            continue
             try:
                 dev = Device(port=int(v.split(":", 1)[1]), host=v.split(":", 1)[0])
                 self._dependent_hardware[k] = dev

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -13,6 +13,9 @@ class HasDependent(Base):
 
         self._dependent_hardware = {}
         for k, v in self.yaq_client.get_dependent_hardware().items():
+            dev = Device(port=int(v.split(":", 1)[1]), host=v.split(":", 1)[0])
+            self._dependent_hardware[k] = dev
+            continue
             try:
                 dev = Device(port=int(v.split(":", 1)[1]), host=v.split(":", 1)[0])
                 self._dependent_hardware[k] = dev

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -18,7 +18,7 @@ class HasDependent(Base):
                 # replace hosts local to my own daemon, which may be remote to the client
                 if host in ("localhost", "127.0.0.1"):
                     host = self.yaq_client._host
-                self.dependent_hardware[k] = Device(port=port, host=host)
+                self.dependent_hardware[k] = Device(port=int(port), host=host)
             except ConnectionError as e:
                 warnings.warn(
                     f"Unable to connect to {k} from {self.name}, ignoring dependent relationship."

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -11,14 +11,14 @@ class HasDependent(Base):
         # Avoid circular import
         from ._device import Device
 
-        self._dependent_hardware = {}
+        self.dependent_hardware = {}
         for k, v in self.yaq_client.get_dependent_hardware().items():
             try:
                 host, port = v.split(":", 1)
                 # replace hosts local to my own daemon, which may be remote to the client
                 if host in ("localhost", "127.0.0.1"):
                     host = self.yaq_client._host
-                self._dependent_hardware[k] = Device(port=port, host=host)
+                self.dependent_hardware[k] = Device(port=port, host=host)
             except ConnectionError as e:
                 warnings.warn(
                     f"Unable to connect to {k} from {self.name}, ignoring dependent relationship."
@@ -26,24 +26,30 @@ class HasDependent(Base):
 
     def _describe(self, out):
         out = super()._describe(out)
-        for d in self._dependent_hardware.values():
+        for d in self.dependent_hardware.values():
             out.update(d.describe())
         return out
 
     def _read(self, out, ts) -> OrderedDict:
         out = super()._read(out, ts)
-        for d in self._dependent_hardware.values():
+        for d in self.dependent_hardware.values():
             out.update(d.read())
         return out
 
     def read_configuration(self) -> OrderedDict:
         out = super().read_configuration()
-        for d in self._dependent_hardware.values():
+        for d in self.dependent_hardware.values():
             out.update(d.read_configuration())
         return out
 
     def describe_configuration(self) -> OrderedDict:
         out = super().describe_configuration()
-        for d in self._dependent_hardware.values():
+        for d in self.dependent_hardware.values():
             out.update(d.describe_configuration())
+        return out
+
+    @property
+    def hints(self):
+        out = super().hints
+        out["yaq dependents"] = list(self.dependent_hardware.keys())
         return out

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -1,0 +1,43 @@
+from collections import OrderedDict
+import time
+import warnings
+
+from ._base import Base
+
+
+class HasDependent(Base):
+    def __init__(self, yaq_client, *, name=None):
+        super().__init__(yaq_client, name=name)
+        self._dependent_hardware = {}
+        for k, v in self.yaq_client.get_dependent_hardware().items():
+            try:
+                dev = Device(port=int(v.split(":", 1)[1]), host=v.split(":", 1)[0])
+                self._dependent_hardware[k] = dev
+            except:
+                warnings.warn(
+                    f"Unable to connect to {k} from {self.name}, ignoring dependent relationship."
+                )
+
+    def _describe(self, out):
+        out = super()._describe(out)
+        for d in self._dependent_hardware.values():
+            out.update(d.describe())
+        return out
+
+    def _read(self, out, ts) -> OrderedDict:
+        out = super()._read(out, ts)
+        for d in self._dependent_hardware.values():
+            out.update(d.read())
+        return out
+
+    def read_configuration(self) -> OrderedDict:
+        out = super().read_configuration()
+        for d in self._dependent_hardware.values():
+            out.update(d.read_configuration())
+        return out
+
+    def describe_configuration(self) -> OrderedDict:
+        out = super().describe_configuration()
+        for d in self._dependent_hardware.values():
+            out.update(d.describe_configuration())
+        return out

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -19,7 +19,7 @@ class HasDependent(Base):
                 if host in ("localhost", "127.0.0.1"):
                     host = self.yaq_client._host
                 setattr(self, k, Device(port=int(port), host=host))
-            except ConnectionError as e:
+            except (ConnectionError, OSError) as e:
                 warnings.warn(
                     f"Unable to connect to {k} from {self.name}, ignoring dependent relationship."
                 )
@@ -27,6 +27,8 @@ class HasDependent(Base):
     def _describe(self, out):
         out = super()._describe(out)
         for d in self._dependent_hardware.keys():
+            if not hasattr(self, d):
+                continue
             d = getattr(self, d)
             out.update(d.describe())
         return out
@@ -34,6 +36,8 @@ class HasDependent(Base):
     def _read(self, out, ts) -> OrderedDict:
         out = super()._read(out, ts)
         for d in self._dependent_hardware.keys():
+            if not hasattr(self, d):
+                continue
             d = getattr(self, d)
             out.update(d.read())
         return out
@@ -41,6 +45,8 @@ class HasDependent(Base):
     def read_configuration(self) -> OrderedDict:
         out = super().read_configuration()
         for d in self._dependent_hardware.keys():
+            if not hasattr(self, d):
+                continue
             d = getattr(self, d)
             out.update(d.read_configuration())
         return out
@@ -48,6 +54,8 @@ class HasDependent(Base):
     def describe_configuration(self) -> OrderedDict:
         out = super().describe_configuration()
         for d in self._dependent_hardware.keys():
+            if not hasattr(self, d):
+                continue
             d = getattr(self, d)
             out.update(d.describe_configuration())
         return out

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -16,7 +16,7 @@ class HasDependent(Base):
             try:
                 dev = Device(port=int(v.split(":", 1)[1]), host=v.split(":", 1)[0])
                 self._dependent_hardware[k] = dev
-            except:
+            except ConnectionError as e:
                 warnings.warn(
                     f"Unable to connect to {k} from {self.name}, ignoring dependent relationship."
                 )

--- a/yaqc_bluesky/_has_dependent.py
+++ b/yaqc_bluesky/_has_dependent.py
@@ -8,6 +8,9 @@ from ._base import Base
 class HasDependent(Base):
     def __init__(self, yaq_client, *, name=None):
         super().__init__(yaq_client, name=name)
+        # Avoid circular import
+        from ._device import Device
+
         self._dependent_hardware = {}
         for k, v in self.yaq_client.get_dependent_hardware().items():
             try:


### PR DESCRIPTION
Closes #18 

This is an initial implementation paired with a change to yaqd-attune, which are the first (And so far only, to my knowledge) daemons to have dependency relations. 

In the future this should likely become a trait and not be a special cased hasattr check, but going quick and dirty for now

I would like to put the keys (regardless of whether connection is successful) somewhere that shows up in the event descriptor doc, just not sure whether that should be in configuration or a custom hints field, maybe?
That will be what is used primarily by UIs/plans, such as for our tuning methods.

One question I have is should we make the dependent hardware dict public, rather than private (as currently implemented) to make it explicit that things like plans can reach in?