### PR TITLE
Add independent flag to mapping data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - namespace dependent hardware to avoid name collisions
 - Invalid splatting of has mapping values into an append call, which only takes one argument
 
+### Added
+- "independent" flag to mapping added fields marking them as independent variables that should not be treated as "channels"
+
 ## [2022.1.0]
 
 ### Added

--- a/yaqc_bluesky/_has_mapping.py
+++ b/yaqc_bluesky/_has_mapping.py
@@ -28,6 +28,7 @@ class HasMapping(Base):
             meta["dims"] = [
                 f"{self.name}_{i}" for i, v in enumerate(self._yaq_mapping_shapes[name]) if v > 1
             ]
+            meta["independent"] = True
             map_dims[name] = set(meta["dims"])
             out[f"{self.name}_{name}"] = OrderedDict(self._field_metadata, **meta)
 


### PR DESCRIPTION
Just a small bit of metadata to differentiate between mapping ("independent variables") and channels ("dependent variables")

Because otherwise we have no differentiatior for what gets made into a WrightTools Channel vs Variable. (we used to use the name, but that got changed to handle cameras more easily)