### PR TITLE
Handle exception in wait until still

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- More error tolerant wait until still method which properly sets the exception of the status object
+
 ## [2022.4.0]
 
 ### Fixed


### PR DESCRIPTION
Allows an intermittent failure, but passes the failure to the status object rather than either hanging or failing outright (and thus causing the status to never "complete" and scans to hang indefinitely